### PR TITLE
Fix windows build

### DIFF
--- a/verilated/src/api.rs
+++ b/verilated/src/api.rs
@@ -25,7 +25,6 @@ mod ffi {
         //pub fn verilated_flush_cb(cb: VerilatedVoidCb);
         pub fn verilated_flush_call();
         pub fn verilated_command_args(argc: c_int, argv: *const *const c_char);
-        pub fn verilated_command_args_add(argc: c_int, argv: *const *const c_char);
         //    static CommandArgValues* getCommandArgs() {return &s_args;}
         pub fn verilated_command_args_plus_match(prefixp: *const c_char) -> *const c_char;
         pub fn verilated_product_name() -> *const c_char;

--- a/verilated/src/vcd.rs
+++ b/verilated/src/vcd.rs
@@ -31,7 +31,14 @@ fn cstr(path: &Path) -> io::Result<CString> {
 
 #[cfg(not(unix))]
 fn cstr(path: &Path) -> io::Result<CString> {
-    Ok(CString::new(path.to_str().expect("path is not valid utf-8").as_bytes())?)
+    Ok(CString::new(
+        path.to_str()
+            .ok_or(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("path is not valid utf-8"),
+            ))?
+            .as_bytes(),
+    )?)
 }
 
 pub struct Vcd(pub *mut VcdC);

--- a/verilated/src/vcd.rs
+++ b/verilated/src/vcd.rs
@@ -1,6 +1,5 @@
 use std::ffi::{CStr, CString};
 use std::io;
-use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 
 pub enum VcdC {}
@@ -24,8 +23,15 @@ mod ffi {
     }
 }
 
+#[cfg(unix)]
 fn cstr(path: &Path) -> io::Result<CString> {
+    use std::os::unix::ffi::OsStrExt;
     Ok(CString::new(path.as_os_str().as_bytes())?)
+}
+
+#[cfg(not(unix))]
+fn cstr(path: &Path) -> io::Result<CString> {
+    Ok(CString::new(path.to_str().expect("path is not valid utf-8").as_bytes())?)
 }
 
 pub struct Vcd(pub *mut VcdC);

--- a/verilated/src/verilated_shim.cpp
+++ b/verilated/src/verilated_shim.cpp
@@ -104,11 +104,6 @@ verilated_command_args(int argc, const char** argv) {
   Verilated::commandArgs(argc, argv);
 }
 
-void
-verilated_command_args_add(int argc, const char** argv) {
-  Verilated::commandArgsAdd(argc, argv);
-}
-
 //    static CommandArgValues* getCommandArgs() {return &s_args;}
 
 /// Match plusargs with a given prefix. Returns static char* valid only for a single call


### PR DESCRIPTION
This adds some patches to get `verilated-rs` running on Windows:

```powershell
[11:10:21 PM] D:/Code/verilated-rs> cargo run
   Compiling verilated v0.1.1 (D:\Code\verilated-rs\verilated)
   Compiling example v0.0.0 (D:\Code\verilated-rs\example)
    Finished dev [unoptimized + debuginfo] target(s) in 12.01s
     Running `target\debug\example.exe`
0: count_o = 0
1: count_o = 0
2: count_o = 1
3: count_o = 2
4: count_o = 3
5: count_o = 4
6: count_o = 5
7: count_o = 6
8: count_o = 7
9: count_o = 8
10: count_o = 9
11: count_o = 10
[11:10:34 PM] D:/Code/verilated-rs>
```