### PR TITLE
verilator v4.038 flush changes.

### DIFF
--- a/verilated/src/api.rs
+++ b/verilated/src/api.rs
@@ -6,6 +6,7 @@ use std::os::raw::{c_char, c_int};
 mod ffi {
     #![allow(dead_code)]
 
+    use std::ffi::c_void;
     use std::os::raw::{c_char, c_int};
 
     extern "C" {
@@ -22,8 +23,6 @@ mod ffi {
         pub fn verilated_assert_on() -> c_int;
         pub fn verilated_set_fatal_on_vpi_error(flag: c_int);
         pub fn verilated_fatal_on_vpi_error() -> c_int;
-        //pub fn verilated_flush_cb(cb: VerilatedVoidCb);
-        pub fn verilated_flush_call();
         pub fn verilated_command_args(argc: c_int, argv: *const *const c_char);
         //    static CommandArgValues* getCommandArgs() {return &s_args;}
         pub fn verilated_command_args_plus_match(prefixp: *const c_char) -> *const c_char;
@@ -31,6 +30,25 @@ mod ffi {
         pub fn verilated_product_version() -> *const c_char;
         pub fn verilated_internals_dump();
         pub fn verilated_scopes_dump();
+    }
+
+    #[cfg(verilator="flush_and_exit_cb")]
+    pub type VoidPCb = unsafe extern "C" fn(*mut c_void);
+
+    #[cfg(verilator="flush_and_exit_cb")]
+    extern "C" {
+        pub fn verilated_add_flush_cb(cb: VoidPCb, datap: *mut c_void);
+        pub fn verilated_remove_flush_cb(cb: VoidPCb, datap: *mut c_void);
+        pub fn verilator_run_flush_callbacks();
+        pub fn verilated_add_exit_cb(cb: VoidPCb, datap: *mut c_void);
+        pub fn verilated_remove_exit_cb(cb: VoidPCb, datap: *mut c_void);
+        pub fn verilator_run_exit_callbacks();
+    }
+
+    #[cfg(not(verilator="flush_and_exit_cb"))]
+    extern "C" {
+        //pub fn verilated_flush_cb(cb: VerilatedVoidCb);
+        pub fn verilated_flush_call();
     }
 }
 

--- a/verilated/src/verilated_shim.cpp
+++ b/verilated/src/verilated_shim.cpp
@@ -87,6 +87,41 @@ verilated_fatal_on_vpi_error() {
   return Verilated::fatalOnVpiError() ? 1 : 0;
 }
 
+#if VERILATOR_VERSION_MAJOR == 4 && VERILATOR_VERSION_MINOR >= 38
+typedef void (*voidp_cb)(void*);  // Callback type for below
+
+/// Callbacks to run on global flush
+void
+verilated_add_flush_cb(voidp_cb cb, void* datap) {
+  Verilated::addFlushCb(cb, datap);
+}
+
+void
+verilated_remove_flush_cb(voidp_cb cb, void* datap) {
+  Verilated::removeFlushCb(cb, datap);
+}
+
+void
+verilator_run_flush_callbacks() {
+  Verilated::runFlushCallbacks();
+}
+
+/// Callbacks to run prior to termination
+void
+verilated_add_exit_cb(voidp_cb cb, void* datap) {
+  Verilated::addExitCb(cb, datap);
+}
+
+void
+verilated_remove_exit_cb(voidp_cb cb, void* datap) {
+  Verilated::removeExitCb(cb, datap);
+}
+
+void
+verilator_run_exit_callbacks() {
+  Verilated::runExitCallbacks();
+}
+#else // !(VERILATOR_VERSION_MAJOR == 4 && VERILATOR_VERSION_MINOR >= 38)
 /// Flush callback for VCD waves
 void
 verilated_flush_cb(VerilatedVoidCb cb) {
@@ -97,6 +132,7 @@ void
 verilated_flush_call() {
   Verilated::flushCall();
 }
+#endif // VERILATOR_VERSION_MAJOR == 4 && VERILATOR_VERSION_MINOR >= 38
 
 /// Record command line arguments, for retrieval by $test$plusargs/$value$plusargs
 void

--- a/verilator/Cargo.toml
+++ b/verilator/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["development-tools::build-utils","development-tools::ffi", "simula
 [dependencies]
 cc = { version = "1.0", optional = true }
 fnv = { version = "1.0", optional = true }
+regex = "1.4"
 syn = { version = "0.13", features = ["extra-traits", "full", "visit"], optional = true }
 
 [features]

--- a/verilator/src/lib.rs
+++ b/verilator/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate cc;
 #[cfg(feature = "module")]
 extern crate fnv;
+extern crate regex;
 #[cfg(feature = "module")]
 extern crate syn;
 
@@ -10,9 +11,11 @@ pub mod gen;
 #[cfg(feature = "module")]
 pub mod module;
 
+use regex::Regex;
 use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::str::from_utf8;
 
 fn check_verilator_bin(path: &Path) -> bool {
     path.join("verilator_bin").is_file()
@@ -20,6 +23,20 @@ fn check_verilator_bin(path: &Path) -> bool {
 
 fn check_verilator_root(root: &Path) -> bool {
     root.join("include/verilated.cpp").is_file()
+}
+
+/// Parse the version of verilator on `$PATH`
+pub fn verilator_version() -> Option<(u32, u32)> {
+    let re = Regex::new(r"^Verilator (\d{1}).(\d{3})").expect("Failed to create version regex");
+    let output = Command::new("verilator_bin")
+        .arg("--version")
+        .output()
+        .ok()?;
+    let stdout = from_utf8(&output.stdout).ok()?;
+    let captures = re.captures(stdout)?;
+    let major = captures[1].parse::<u32>().ok()?;
+    let minor = captures[2].parse::<u32>().ok()?;
+    Some((major, minor))
 }
 
 pub fn find_verilator_root() -> Option<PathBuf> {


### PR DESCRIPTION
The interface to running callbacks on flush changes in Verilator v4.038.
Add support to check version of verilator being used and compile in the
the correct methods in the shim.

Going forward, verilated-rs will drop support for Verilator versions
before v4.108