### PR TITLE
Enable performance optimisations in verilator

### DIFF
--- a/verilator/src/gen.rs
+++ b/verilator/src/gen.rs
@@ -315,7 +315,7 @@ impl Default for Verilator {
             module_directories: Vec::new(),
             coverage: false,
             trace: false,
-            optimized: true,
+            optimized: false,
             suppress_warnings: Vec::new(),
         }
     }

--- a/verilator/src/gen.rs
+++ b/verilator/src/gen.rs
@@ -25,6 +25,7 @@ pub struct Verilator {
     module_directories: Vec<PathBuf>,
     coverage: bool,
     trace: bool,
+    optimized: bool, 
     suppress_warnings: Vec<String>,
 }
 
@@ -107,6 +108,11 @@ impl Verilator {
         self
     }
 
+    pub fn with_performance_optimizations(&mut self, t: bool) -> &mut Verilator {
+        self.optimized = t;
+        self
+    }
+
     pub fn warn_width(&mut self, t: bool) -> &mut Verilator {
         if !t {
             self.suppress_warnings.push("width".to_string());
@@ -160,6 +166,10 @@ impl Verilator {
 
         if self.trace {
             cmd.arg("--trace");
+        }
+
+        if self.optimized {
+            cmd.arg("-O3");
         }
 
         for warn in &self.suppress_warnings {
@@ -305,6 +315,7 @@ impl Default for Verilator {
             module_directories: Vec::new(),
             coverage: false,
             trace: false,
+            optimized: true,
             suppress_warnings: Vec::new(),
         }
     }


### PR DESCRIPTION
As per verilator documentation:

> `-O3` Enables slow optimizations for the code Verilator itself generates (as opposed to `"-CFLAGS -O3"` which effects the C compiler's optimization. `-O3` may improve simulation performance at the cost of compile time.

This PR adds a `.with_performance_optimizations(bool)` to the builder.