### PR TITLE
fix: handle major version 5+ in preproc checks

### DIFF
--- a/verilated/src/verilated_shim.cpp
+++ b/verilated/src/verilated_shim.cpp
@@ -87,7 +87,7 @@ verilated_fatal_on_vpi_error() {
   return Verilated::fatalOnVpiError() ? 1 : 0;
 }
 
-#if VERILATOR_VERSION_MAJOR == 4 && VERILATOR_VERSION_MINOR >= 38
+#if VERILATOR_VERSION_MAJOR > 4 || (VERILATOR_VERSION_MAJOR == 4 && VERILATOR_VERSION_MINOR >= 38)
 typedef void (*voidp_cb)(void*);  // Callback type for below
 
 /// Callbacks to run on global flush
@@ -121,7 +121,7 @@ void
 verilator_run_exit_callbacks() {
   Verilated::runExitCallbacks();
 }
-#else // !(VERILATOR_VERSION_MAJOR == 4 && VERILATOR_VERSION_MINOR >= 38)
+#else // !(VERILATOR_VERSION_MAJOR > 4 || (VERILATOR_VERSION_MAJOR == 4 && VERILATOR_VERSION_MINOR >= 38))
 /// Flush callback for VCD waves
 void
 verilated_flush_cb(VerilatedVoidCb cb) {
@@ -132,7 +132,7 @@ void
 verilated_flush_call() {
   Verilated::flushCall();
 }
-#endif // VERILATOR_VERSION_MAJOR == 4 && VERILATOR_VERSION_MINOR >= 38
+#endif // VERILATOR_VERSION_MAJOR > 4 || (VERILATOR_VERSION_MAJOR == 4 && VERILATOR_VERSION_MINOR >= 38)
 
 /// Record command line arguments, for retrieval by $test$plusargs/$value$plusargs
 void

--- a/verilated/src/verilatedvcdc_shim.cpp
+++ b/verilated/src/verilatedvcdc_shim.cpp
@@ -41,11 +41,19 @@ verilatedvcdc_open_next(VerilatedVcdC* vcd, int inc_filename) {
   vcd->openNext(inc_filename ? true : false);
 }
 
+#if VERILATOR_VERSION_MAJOR > 4 || (VERILATOR_VERSION_MAJOR == 4 && VERILATOR_VERSION_MINOR >= 226)
+/// Set size in bytes after which new file should be created.
+void
+verilatedvcdc_rollover_size(VerilatedVcdC* vcd, size_t size) {
+    vcd->rolloverSize(size);
+}
+#else // !(VERILATOR_VERSION_MAJOR > 4 || (VERILATOR_VERSION_MAJOR == 4 && VERILATOR_VERSION_MINOR >= 226))
 /// Set size in megabytes after which new file should be created
 void
 verilatedvcdc_rollover_mb(VerilatedVcdC* vcd, size_t rolloverMB) {
     vcd->rolloverMB(rolloverMB);
 }
+#endif // VERILATOR_VERSION_MAJOR > 4 || (VERILATOR_VERSION_MAJOR == 4 && VERILATOR_VERSION_MINOR >= 226)
 
 /// Close dump
 void


### PR DESCRIPTION
This PR updates some preprocessor checks to no longer assume that 4 is the latest Verilator major version. It also incorporates the renaming of `rolloverMB()` to `rolloverSize()` in v4.226.

This is only a partial fix -- the examples still do not build with Verilator 5, but these fixes result in more progress.